### PR TITLE
Update repl.lisp

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -1,4 +1,4 @@
-#!/usr/local/bin/sbcl --script
+#!/usr/bin/env sbcl --script
 (load "~/quicklisp/setup")
 
 (let ((*standard-output* (make-broadcast-stream)))


### PR DESCRIPTION
Change shebang to use `env` - previous shebang had assumptions about sbcl location. With wrong location when running I would get 
```
The file 'sbcli' is marked as an executable but could not be run by the operating system.
```
