### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ and has readline capabilities.
 ## Installation
 
 For most cases, calling `./install.sh` should suffice. It will
-install `sbcli` into `/usr/local/bin`.
+install `sbcli` into `/usr/local/bin`. If you are using Mac and having issues with `cl-readline` see [installation notes for cl-readline](https://github.com/mrkkrp/cl-readline#installation).
 
 ## Dependencies
 


### PR DESCRIPTION
Add note on cl-readline & mac - I don't insist on putting this into readme, but I would dump error message here:
```
Unhandled SIMPLE-ERROR in thread #<SB-THREAD:THREAD "main thread" RUNNING
                                    {1001930083}>:
  Trying to access undefined foreign variable "rl_num_chars_to_read".
```
so people might see this issue if they are having this same error (`brew link readline --force` fixed it for me, as described in cl-readline's readme)