### PR TITLE
Fix env not passing options of sbcl for it when running the script.

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -1,4 +1,4 @@
-#!/usr/bin/env sbcl --script
+#!/usr/bin/env -S sbcl --script
 (load "~/quicklisp/setup")
 
 (let ((*standard-output* (make-broadcast-stream)))


### PR DESCRIPTION
This is a fix of the following error on Arch Linux.

/usr/bin/env: “sbcl --script”: File or directory not found