### PR TITLE
Improved install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ and has readline capabilities, including multiline input and reset.
 ## Installation
 
 For most cases, calling `./install.sh` should suffice. It will
-install `sbcli` into `/usr/local/bin`. If you are using Mac and having
+install `sbcli` into `$PREFIX/bin`, with the environment variable `PREFIX`
+defaulting to `/usr/local`. If you are using Mac and having
 issues with `cl-readline` see the [installation notes for
 cl-readline](https://github.com/mrkkrp/cl-readline#installation).
 

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 cp repl.lisp ${PREFIX:-/usr/local}/bin/sbcli

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-cp repl.lisp ${PREFIX:-/usr/local}/bin/sbcli
+install -Dm755 repl.lisp ${PREFIX:-/usr/local}/bin/sbcli

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cp repl.lisp /usr/local/bin/sbcli
+cp repl.lisp ${PREFIX:-/usr/local}/bin/sbcli


### PR DESCRIPTION
I've made some improvements to `install.sh` if you're interested. The script now:
- Runs using POSIX Shell instead of bash (faster and better compatibility).
- Respects the `PREFIX` environment variable (so maintainers can install to `/usr/bin`).
- Uses `install` instead of `cp` (makes sure that permissions and directories are correct).