### PR TITLE
:doc of a function: print its argument list

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -3,7 +3,8 @@
 
 (let ((*standard-output* (make-broadcast-stream)))
   (ql:quickload "alexandria")
-  (ql:quickload "cl-readline"))
+  (ql:quickload "cl-readline")
+  (ql:quickload "trivial-arguments"))
 
 (defpackage :sbcli
   (:use :common-lisp :cffi)
@@ -102,7 +103,9 @@
                                   symbol/string)
                    for doc = (documentation sym doc-type)
                    when doc
-                   do (format t "~a: ~a~&" doc-type doc))
+                   do (format t "~a: ~a~&" doc-type doc)
+                   and when (equal doc-type 'function)
+                   do (format t "ARGLIST: ~a~&" (trivial-arguments:arglist sym))))
     (error (c) (format *error-output* "Error during documentation lookup: ~a~&" c))))
 
 (defun general-help ()

--- a/repl.lisp
+++ b/repl.lisp
@@ -5,6 +5,8 @@
   (ql:quickload "alexandria")
   (ql:quickload "cl-readline"))
 
+(require :sb-introspect)
+
 (defpackage :sbcli
   (:use :common-lisp :cffi)
   (:export sbcli *repl-version* *repl-name* *prompt* *prompt2* *ret* *config-file*

--- a/repl.lisp
+++ b/repl.lisp
@@ -100,7 +100,9 @@
                                   (read-from-string symbol/string)
                                   ;; used from Slime
                                   symbol/string)
-                   for doc = (documentation sym doc-type)
+                   for doc = (unless (consp sym)
+                               ;; When the user enters :doc 'sym instead of :doc sym
+                               (documentation sym doc-type))
                    when doc
                    do (format t "~a: ~a~&" doc-type doc)
                    and when (equal doc-type 'function)

--- a/repl.lisp
+++ b/repl.lisp
@@ -3,8 +3,7 @@
 
 (let ((*standard-output* (make-broadcast-stream)))
   (ql:quickload "alexandria")
-  (ql:quickload "cl-readline")
-  (ql:quickload "trivial-arguments"))
+  (ql:quickload "cl-readline"))
 
 (defpackage :sbcli
   (:use :common-lisp :cffi)
@@ -105,7 +104,8 @@
                    when doc
                    do (format t "~a: ~a~&" doc-type doc)
                    and when (equal doc-type 'function)
-                   do (format t "ARGLIST: ~a~&" (trivial-arguments:arglist sym))))
+                   do (format t "ARGLIST: ~a~&"
+                              (sb-introspect:function-lambda-list sym)))
     (error (c) (format *error-output* "Error during documentation lookup: ~a~&" c))))
 
 (defun general-help ()


### PR DESCRIPTION
Hello,

I figured it is useful to see the actual parameters of the function we are getting the documentation of.

```
> :doc parse-integer
FUNCTION: Examine the substring of string delimited by start and end
  (default to the beginning and end of the string)  It skips over
  whitespace characters and then tries to parse an integer. The
  radix parameter must be between 2 and 36.
ARGLIST: (STRING &KEY (START 0) END (RADIX 10) JUNK-ALLOWED)
```

I use a portable library. Under SBCL, it is

        (sb-introspect:function-lambda-list function)

Note: on my side I downcased the arglist with this, but there's certainly a format solution:
 
        do (format t "ARGLIST: ~a~&" (str:downcase (str:unwords (arglist sym)))))
