### PR TITLE
repl: better completion according to the package

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -3,7 +3,8 @@
 
 (let ((*standard-output* (make-broadcast-stream)))
   (ql:quickload "alexandria")
-  (ql:quickload "cl-readline"))
+  (ql:quickload "cl-readline")
+  (ql:quickload "str"))
 
 (require :sb-introspect)
 
@@ -150,39 +151,119 @@
     (sb-int:compiled-program-error (err) (format t "~a~%" err))
     (undefined-function (fun) (format t "~a~%" fun))))
 
-(defun common-prefix (items)
-  (let ((lst 0))
-    (loop for n from 1 below (reduce #'min (mapcar #'length items)) do
-      (when (every (lambda (x)
-                      (char= (char (car items) n)
-                             (char x           n)))
-              (cdr items))
-       (setf lst n)))
-   (subseq (car items) 0 (1+ lst))))
+(defun get-package-for-search (text)
+  "Return a list with:
+  - the text after the colon or double colon
+  - the package name (a string)
+  - T if we are looking for an external symbol, NIL for an internal one."
+  (let ((pos))
+    (cond
+      ((setf pos (search "::" text))
+       (list (subseq text  (+ pos 2))
+             (subseq text 0 pos)
+             nil))
+      ((setf pos (position #\: text))
+       (if (zerop pos)
+           (list text nil t)
+           (list (subseq text (1+ pos))
+                 (subseq text 0 pos)
+                 t)))
+      (t (list text nil  t)))))
 
-(defun starts-with (text)
-  (lambda (sym)
-    (let* ((symstr (string-downcase sym))
-           (cmp (subseq symstr 0 (min (length symstr) (length text)))))
-      (string= text cmp))))
+#+or(nil)
+(progn
+  (assert (equal (list "file-" "uiop" t)
+                 (get-package-for-search "uiop:file-")))
+  (assert (equal (list "*wil" "uiop" nil)
+                 (get-package-for-search "uiop::*wil")))
+  (assert (equal (list "*feat" nil t)
+                 (get-package-for-search "*feat"))))
 
-(defun select-completions (text list)
- (let* ((els (remove-if-not (starts-with text)
-                           (mapcar #'string list)))
-        (els (if (cdr els) (cons (common-prefix els) els) els)))
-    (if (string= text (string-downcase text))
-      (mapcar #'string-downcase els)
-      els)))
+(defun list-external-symbols (sym-name pkg-name)
+  "List external symbols of PKG-NAME (a string).
+  (the symbol name is currently ignored)."
+  (declare (ignorable sym-name))
+  (assert (stringp pkg-name))
+  (loop :for sym :being :the :external-symbols :of (find-package pkg-name)
+     :collect (format nil "~(~a:~a~)" pkg-name sym)))
 
-(defun get-all-symbols ()
-  (let ((lst ()))
-    (do-all-symbols (s lst)
-      (when (or (fboundp s) (boundp s)) (push s lst)))
-    lst))
+(defun list-internal-symbols (sym-name pkg-name)
+  "List internal symbols of the package named PKG-NAME (a string)."
+  (declare (ignorable sym-name))
+  (assert (stringp pkg-name))
+  (loop :for sym :being :the :symbols :of (find-package pkg-name)
+     :collect (format nil "~(~a::~a~)" pkg-name sym)))
 
-(defun custom-complete (text start end)
-  (declare (ignore start) (ignore end))
-  (select-completions text (get-all-symbols)))
+(defun list-symbols-and-packages (sym-name)
+  "Base case, when the user entered a string with no colon that would delimit a package.
+  Return the current packages, symbols of the current package, current keywords.
+  They are filtered afterwards, in SELECT-COMPLETIONS."
+  (declare (ignorable sym-name))
+  (concatenate 'list
+               (loop :for pkg :in (list-all-packages)
+                  :append (loop :for name :in (package-nicknames pkg)
+                             :collect (format nil "~(~a:~)" name))
+                  :collect (format nil "~(~a:~)" (package-name pkg)))
+               (loop :for sym :being :the :symbols :of *package*
+                  :collect (string-downcase sym))
+               (loop :for kw :being :the :symbols :of (find-package "KEYWORD")
+                  :collect (format nil ":~(~a~)" kw))))
+
+(defun select-completions (text items)
+  "TEXT is the string entered at the prompt, ITEMS is a list of
+strings to match candidates against (for example in the form \"package:sym\")."
+  (setf items
+        (loop :for item :in items
+           :when (str:starts-with-p text item)
+           :collect item))
+  (unless (cdr items)
+    (setf rl:*completion-append-character*
+          (if (str:ends-with-p ":" (car items))
+              #\nul
+              #\space))
+    (return-from select-completions items))
+  (cons
+   (subseq (car items) 0
+           (loop :for item :in (cdr items)
+              :minimize (or (mismatch (car items) item) (length item))))
+   items))
+
+#+or(nil)
+(progn
+  (assert (member "str:concat"
+                  (select-completions "str:con" (list "str:containsp" "str:concat" "str:constant-case"))
+                  :test #'string-equal)))
+
+(defun custom-complete (text &optional start end)
+  "Custom completer function for readline, triggered when we press TAB.
+
+  START and END are accepted by readline but are not used."
+  (declare (ignore start end))
+  (when (string-equal text "")
+    (return-from custom-complete nil))
+  (destructuring-bind (sym-name pkg-name external-p)
+      (get-package-for-search (string-upcase text))
+    (when (and pkg-name
+               (not (find-package pkg-name)))
+      (return-from custom-complete nil))
+    (select-completions
+     (str:downcase text)
+     (cond
+       ((zerop (length pkg-name))
+        (list-symbols-and-packages sym-name))
+       (external-p
+        (list-external-symbols sym-name pkg-name))
+       (t
+        (list-internal-symbols sym-name pkg-name))))))
+
+#+or(nil)
+(progn
+  (assert (member "str:suffixp"
+                  (custom-complete "str:suff")
+                  :test #'string-equal))
+  (assert (member "uiop:file-exists-p"
+                  (custom-complete "uiop:file-")
+                  :test #'string-equal)))
 
 (rl:register-function :complete #'custom-complete)
 


### PR DESCRIPTION
I think that's it. Would need some more usage to see.

fixes #12 

previously:

1- searching "(file-e" listed ALL existing symbols of ALL packages,
  and returned a lot of results.
2- while searching "(uiop:file-e" didn't return uiop's functions.

now:

1 returns one symbol,
2 completes uiop's external symbols, as expected.
 (also works with internal symbols)

Largely adapted from cl-repl.