### PR TITLE
Syntax Highlighting using pygmentize

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ For reference, here is a complete list of the variables we expose:
 ; the history variable
 ; while nothing prevents you from writing to it, i advise against it
 *hist*         ; => ()
+
+; you can optionally set a path to pygmentize to enable syntax-coloring
+; in the REPL
+*pygmentize*
 ```
 
 <hr/>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # sbcli
 
-A better REPL for SBCL. It handles errors greacefully, is not too verbose, and
-has readline capabilities, including multiline input and reset.
+A better REPL for SBCL. It handles errors greacefully, is not too verbose, has
+readline capabilities, including multiline input and reset, and has optional
+syntax highlighting capabilities using [pygmentize](https://pygments.org/).
 
 ## Installation
 
@@ -84,8 +85,11 @@ For reference, here is a complete list of the variables we expose:
 *hist*         ; => ()
 
 ; you can optionally set a path to pygmentize to enable syntax-coloring
-; in the REPL
-*pygmentize*
+; in the REPL. N.B: might lead to slower rendering speed
+;
+; if you're unsure what to put there, i suggest using
+; [which](https://github.com/eudoxia0/which)
+*pygmentize* ; => nil
 ```
 
 <hr/>

--- a/examples/.sbclirc
+++ b/examples/.sbclirc
@@ -3,3 +3,5 @@
 (setf *ret*       "=>")
 (setf *repl-name* "My Super Custom REPL")
 (setf *hist-file* "~/.x") ; set to empty string or nil to disable
+(setf *pygmentize* "/path/to/pygmentize/exe") ; path to pygmentize for highlighting;
+                                              ; set to nil to disable

--- a/repl.lisp
+++ b/repl.lisp
@@ -309,6 +309,7 @@ strings to match candidates against (for example in the form \"package:sym\")."
     (finish-output)))
 
 (rl:register-function :complete #'custom-complete)
+(rl:register-function :redisplay #'syntax-hl)
 
 ;; -1 means take the string as one arg
 (defvar *special*

--- a/repl.lisp
+++ b/repl.lisp
@@ -293,7 +293,7 @@ strings to match candidates against (for example in the form \"package:sym\")."
 (defun maybe-highlight (str)
   (if *pygmentize*
     (with-input-from-string (s str)
-      (let ((proc (sb-ext:run-program "/usr/local/bin/pygmentize"
+      (let ((proc (sb-ext:run-program *pygmentize*
                                       (list "-s" "-l" "lisp")
                                       :input s
                                       :output :stream)))

--- a/repl.lisp
+++ b/repl.lisp
@@ -309,7 +309,6 @@ strings to match candidates against (for example in the form \"package:sym\")."
     (finish-output)))
 
 (rl:register-function :complete #'custom-complete)
-(rl:register-function :redisplay #'syntax-hl)
 
 ;; -1 means take the string as one arg
 (defvar *special*
@@ -408,6 +407,7 @@ strings to match candidates against (for example in the form \"package:sym\")."
        (sbcli::handle-input txt text)))
     (in-package :sbcli)
     (finish-output nil)
+    (rl:register-function :redisplay #'syntax-hl)
     (sbcli "" *prompt*)))
 
 (if (probe-file *config-file*)


### PR DESCRIPTION
This PR adds optional syntax highlighting by shelling out to pygmentize. I don’t love that approach, but it is pretty simple, and I didn’t want to go through the pains of doing syntax analysis myself for now.

Cheers