### PR TITLE
REPL arglist: always print arglist, fix formatting

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -108,9 +108,10 @@
                                (documentation sym doc-type))
                    when doc
                    do (format t "~a: ~a~&" doc-type doc)
-                   and when (equal doc-type 'function)
+                   when (equal doc-type 'function)
                    do (format t "ARGLIST: ~a~&"
-                              (sb-introspect:function-lambda-list sym)))
+                              (format nil "~(~a~)"
+                                      (sb-introspect:function-lambda-list sym))))
     (error (c) (format *error-output* "Error during documentation lookup: ~a~&" c))))
 
 (defun general-help ()


### PR DESCRIPTION
Print the arglist even if no documentation was found (that's the
point!).
Fix printing of long arglists.

---

A quick fix. Try with quickloading cl-csv and 

    :doc #'cl-csv:read-csv

Now we get

```
sbcl> :doc cl-csv:read-csv
ARGLIST: (stream-or-string &rest all-keys &key csv-reader row-fn map-fn data-map-fn
 sample skip-first-p ((separator *separator*) *separator*)
 ((quote *quote*) *quote*) ((escape *quote-escape*) *quote-escape*)
 ((unquoted-empty-string-is-nil *unquoted-empty-string-is-nil*)
  *unquoted-empty-string-is-nil*)
 ((quoted-empty-string-is-nil *quoted-empty-string-is-nil*)
  *quoted-empty-string-is-nil*)
 ((trim-outer-whitespace *trim-outer-whitespace*) *trim-outer-whitespace*)
 ((newline *read-newline*) *read-newline*)
 ((escape-mode *escape-mode*) *escape-mode*))
```