### PR TITLE
repl: trailing " ?" trick to print the symbol's documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ exits inspection mode.
 
 Typing `:doc symbol` prints the available documentation for this symbol.
 
+Typing `(symbol ?` also prints the available documentation for this symbol.
+
 Typing `:q`, `CTRL-D`, or `CTRL-C` will exit the REPL.
 
 Typing `:r` resets the environment.

--- a/repl.lisp
+++ b/repl.lisp
@@ -334,7 +334,15 @@ strings to match candidates against (for example in the form \"package:sym\")."
     (unless text (end))
     (if (string= text "") (sbcli "" *prompt*))
     (when *hist-file* (update-hist-file text))
-    (handle-input txt text)
+    (cond
+      ((str:ends-with-p " ?" text)
+       ;; a trailing " ?" prints the symbol documentation.
+       (sbcli::symbol-documentation (str:trim
+                                     (str:replace-using (list "("  ""
+                                                              " ?" "")
+                                                        text))))
+      (t
+       (sbcli::handle-input txt text)))
     (in-package :sbcli)
     (finish-output nil)
     (sbcli "" *prompt*)))

--- a/repl.lisp
+++ b/repl.lisp
@@ -29,6 +29,8 @@
 (defvar *hist*         (list))
 (declaim (special *special*))
 
+(load "utils.lisp")
+
 (defun read-hist-file ()
   (with-open-file (in *hist-file* :if-does-not-exist :create)
     (loop for line = (read-line in nil nil)
@@ -338,10 +340,7 @@ strings to match candidates against (for example in the form \"package:sym\")."
     (cond
       ((str:ends-with-p " ?" text)
        ;; a trailing " ?" prints the symbol documentation.
-       (sbcli::symbol-documentation (str:trim
-                                     (str:replace-using (list "("  ""
-                                                              " ?" "")
-                                                        text))))
+       (sbcli::symbol-documentation (last-nested-expr text)))
       (t
        (sbcli::handle-input txt text)))
     (in-package :sbcli)

--- a/repl.lisp
+++ b/repl.lisp
@@ -108,7 +108,8 @@
                                (documentation sym doc-type))
                    when doc
                    do (format t "~a: ~a~&" doc-type doc)
-                   when (equal doc-type 'function)
+                   when (and (equal doc-type 'function)
+                             (fboundp sym))
                    do (format t "ARGLIST: ~a~&"
                               (format nil "~(~a~)"
                                       (sb-introspect:function-lambda-list sym))))

--- a/utils.lisp
+++ b/utils.lisp
@@ -1,0 +1,23 @@
+
+(defun last-nested-expr (s/sexp)
+  "From an input with nested parens (or none), return the most nested
+function call (or the first thing at the prompt).
+
+(hello (foo (bar:qux *zz* ?
+=>
+bar:qux
+"
+  (let* ((input (str:trim s/sexp))
+         (last-parens-token (first (last (str:split #\( input)))))
+    (first (str:words last-parens-token))))
+
+#+or(nil)
+(progn
+  (assert (string= "baz:qux"
+                   (last-nested-expr "(hello (foo bar (baz:qux zz ?")))
+  (assert (string= "baz:qux"
+                   (last-nested-expr "(baz:qux zz ?")))
+  (assert (string= "qux"
+                   (last-nested-expr "(baz (qux ?")))
+  (assert (string= "sym"
+                   (last-nested-expr "sym ?"))))


### PR DESCRIPTION
I propose another shortcut to print the documentation. Now we can TAB-complete a symbol and wonder "oh, I actually need to see its documentation", and we can type " ?" and get it, instead of erasing the beginning of the line to write `:doc`.