### PR TITLE
repl: print result as is, not æsthetically

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -313,7 +313,7 @@ strings to match candidates against (for example in the form \"package:sym\")."
           (error (condition)
             (format *error-output* "Evaluation error: ~a~%" condition))))
   (add-res text *last-result*)
-  (if *last-result* (format t "~a~a~%" *ret* *last-result*)))
+  (if *last-result* (format t "~a~s~%" *ret* *last-result*)))
 
 (defun handle-lisp (before text)
   (let* ((new-txt (format nil "~a ~a" before text))


### PR DESCRIPTION
It is difficult to know if the result is a string or a symbol, because
they are printed without quotes or colons.

~a "foo" prints foo
~a :foo prints foo

now:

~s "foo" prints "foo"
~s :foo prints :foo