### PR TITLE
tiny fix on format string for condition error output

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -318,7 +318,7 @@ strings to match candidates against (for example in the form \"package:sym\")."
             (sb-int:compiled-program-error ()
               (format *error-output* "Compiler error.~%"))
             (error (condition)
-              (format *error-output* "~Evaluation error: ~a~%" condition))))))
+              (format *error-output* "Evaluation error: ~a~%" condition))))))
     (when result-list
       (add-res text (car result-list))
       (setf +++ ++


### PR DESCRIPTION
`(FORMAT *ERROR-OUTPUT* "~Evaluation error: ~a~%" CONDITION)` had an extra tilde at the start, causing it to ask for two arguments.