### PR TITLE
Look for quicklisp in /var/lib or /home directory

### DIFF
--- a/repl.lisp
+++ b/repl.lisp
@@ -1,5 +1,19 @@
 #!/usr/bin/env -S sbcl --script
-(load "~/quicklisp/setup")
+
+;; check for the two most likely places quicklisp is installed and try to load it
+;; on v-refracta, it is simply installed in /var/lib/
+(let ((home-quicklisp (merge-pathnames "quicklisp/setup.lisp" (user-homedir-pathname)))
+  (var-quicklisp (merge-pathnames "setup.lisp" #p"/var/lib/quicklisp/")))
+  (handler-case
+      (cond
+        ((not (null (probe-file home-quicklisp))) (load home-quicklisp))
+        ((not (null (probe-file var-quicklisp)))  (load var-quicklisp))
+        (t
+          (error 'simple-package-error
+            :package "QUICKLISP-CLIENT"
+            :format-control "Quicklisp does not appear to be installed.~%")))
+    (package-error (condition)
+      (format *error-output* "Quicklisp does not appear to be installed.~%" condition))))
 
 (let ((*standard-output* (make-broadcast-stream)))
   (ql:quickload "alexandria")


### PR DESCRIPTION
I am working on a Linux distribution called v-refracta, and on it most of the programs are supposed to be Lisp.

Here I've patched sbcli to look in either the home directory or a "standard" directory for quicklisp installed by a distribution package.
I'm open to putting quicklisp in a different directory than `/var/lib/quicklisp`, and if you can think of a better one you could change it here. (I assumed it needed to go in [/var](https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05.html#purpose31) because it was going to be written to in less predictable ways than is expected with `/usr/share`.)